### PR TITLE
Parser bug

### DIFF
--- a/src/parsers/default_parser.py
+++ b/src/parsers/default_parser.py
@@ -18,7 +18,7 @@ class DefaultParser:
         with open(filepath) as f:
             contents = f.read()
         data = [json.loads(item) for item in contents.strip().split('\n')]
-        data = sorted(data, key=lambda x: x['number'])
+        data = sorted(data, key=lambda x: x['timestamp'])
         return data
 
     def parse(self):


### PR DESCRIPTION
The default parser was using the block's "number" for sorting, but it was used as string instead of integer (so, e.g. "100000" was considered lower than "3"). Use timestamp instead.