### PR TITLE
Fix accidental indent

### DIFF
--- a/src/mappings/tezos.py
+++ b/src/mappings/tezos.py
@@ -37,9 +37,9 @@ class TezosMapping(Mapping):
                 daily_helper_data[day]['pool_links'] = pool_links
                 daily_helper_data[day]['pool_addresses'] = pool_addresses
 
-                coinbase_addresses = tx['coinbase_addresses']
-                if coinbase_addresses is None:
-                    coinbase_addresses = '----- UNDEFINED MINER -----'
+            coinbase_addresses = tx['coinbase_addresses']
+            if coinbase_addresses is None:
+                coinbase_addresses = '----- UNDEFINED MINER -----'
 
             if coinbase_addresses in pool_addresses.keys():
                 entity = pool_addresses[coinbase_addresses]


### PR DESCRIPTION
Because of the indentation, the coinbase addresses in Tezos mapping were not updated for each transaction. Now that this is fixed the tests should pass.