### PR TITLE
Add default_ledgers to config file

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -6,3 +6,13 @@ metrics:
   gini:
   hhi:
   nakamoto_coefficient:
+
+default_ledgers:
+  - bitcoin
+  - bitcoin_cash
+  - cardano
+  - dogecoin
+  - ethereum
+  - litecoin
+  - tezos
+  - zcash

--- a/run.py
+++ b/run.py
@@ -1,12 +1,10 @@
 import argparse
-from src.map import ledger_mapping, apply_mapping
+from src.map import apply_mapping
 from src.analyze import analyze
 from src.parse import parse
 from src.plot import plot
-from src.helpers.helper import valid_date
-from src.helpers.helper import INPUT_DIR, OUTPUT_DIR
+from src.helpers.helper import valid_date, INPUT_DIR, OUTPUT_DIR, get_default_ledgers
 
-PROJECTS = ledger_mapping.keys()
 
 START_YEAR = 2018
 END_YEAR = 2024
@@ -38,14 +36,15 @@ def main(projects, timeframes, force_parse, force_map, make_plots, make_animated
 
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser()
+    default_ledgers = get_default_ledgers()
 
+    parser = argparse.ArgumentParser()
     parser.add_argument(
         '--ledgers',
         nargs="*",
         type=str.lower,
-        default=PROJECTS,
-        choices=[ledger for ledger in PROJECTS],
+        default=default_ledgers,
+        choices=[ledger for ledger in default_ledgers],
         help='The ledgers that will be analyzed.'
     )
     parser.add_argument(

--- a/src/helpers/helper.py
+++ b/src/helpers/helper.py
@@ -239,20 +239,29 @@ def get_special_addresses(project_name):
     return set([addr['address'] for addr in special_addresses])
 
 
+def get_config_data():
+    """
+    Reads the configuration data of the project. This data is read from a file named "confing.yaml" located at the
+    root directory of the project.
+    :returns: a dictionary of configuration keys and values
+    """
+    with open(ROOT_DIR / "config.yaml") as f:
+        config = safe_load(f)
+    return config
+
+
 def get_metrics_config():
     """
-    Reads data about the metrics that will be used. The data is read from a file named "confing.yaml" located at the
-    root directory of the project. All metrics that are mentioned in the file (not in comments) will be used at the
-    "analyze" and "plot" stages. If a metric is parameterized, then the values of its parameters are also given in
-    this file. To add a new metric, one can add a new entry in the file, and to disable a metric it suffices to comment
-    out the relevant line(s).
+    Reads data about the metrics that will be used from the project's config file. All metrics that are mentioned in
+    the file (not in comments) will be used at the "analyze" and "plot" stages. If a metric is parameterized, then the
+    values of its parameters are also given in this file. To add a new metric, one can add a new entry in the file, and
+    to disable a metric it suffices to comment out the relevant line(s).
     :returns: a dictionary where the keys correspond to metric names and the values to their configurations
     (dictionary of parameter - value pairs for each parameter that the metric takes)
     :raises AssertionError if the file defines different parameter values for metrics that are supposed to be
     consistent (e.g. entropy and entropy percentage)
     """
-    with open(ROOT_DIR / "config.yaml") as f:
-        config = safe_load(f)
+    config = get_config_data()
     metrics = config['metrics']
     metric_families = [['entropy', 'entropy_percentage']]
     for metric_family in metric_families:
@@ -266,3 +275,14 @@ def get_metrics_config():
                                                   "percentage) must use the same parameter values. " \
                                                   "Please update your config.yaml file accordingly."
     return metrics
+
+
+def get_default_ledgers():
+    """
+    Retrieves data regarding the default ledgers to use
+    :returns: a list of strings that correspond to the ledgers that will be used (unless overriden by the relevant cmd
+    arg)
+    """
+    config = get_config_data()
+    ledgers = config['default_ledgers']
+    return ledgers

--- a/tests/test_2_helper.py
+++ b/tests/test_2_helper.py
@@ -5,7 +5,7 @@ import shutil
 import pytest
 from src.helpers.helper import get_known_entities, get_pool_data, write_blocks_per_entity_to_file, \
     get_blocks_per_entity_from_file, get_blocks_per_entity_group_from_file, get_timeframe_beginning, \
-    get_timeframe_end, get_time_period, valid_date, OUTPUT_DIR
+    get_timeframe_end, get_time_period, get_default_ledgers, valid_date, OUTPUT_DIR
 from src.map import ledger_mapping
 
 
@@ -199,3 +199,9 @@ def test_get_known_entities():
     # check legal links
     assert "Bitmain" in known_entities
     assert "NovaBlock" in known_entities
+
+
+def test_get_default_ledgers():
+    ledgers = get_default_ledgers()
+    assert type(ledgers) == list
+    assert len(ledgers) > 0


### PR DESCRIPTION
Allow the default ledgers to diverge from the set of all supported ledgers by including a relevant key in the config file. Also list them in alphabetical order (which is preserved in the output files).