### PR TITLE
Add same timestamp condition to queries + order

### DIFF
--- a/queries.yaml
+++ b/queries.yaml
@@ -4,7 +4,7 @@ bitcoin:
   JOIN `bigquery-public-data.crypto_bitcoin.blocks` ON `bigquery-public-data.crypto_bitcoin.transactions`.block_number = `bigquery-public-data.crypto_bitcoin.blocks`.number
   WHERE is_coinbase is TRUE
   AND timestamp > '2018-01-01'
-  ORDER BY number
+  ORDER BY timestamp
 
 bitcoin_cash:
   SELECT block_number as number, block_timestamp as timestamp, coinbase_param as identifiers, `bigquery-public-data.crypto_bitcoin_cash.transactions`.outputs
@@ -12,14 +12,14 @@ bitcoin_cash:
   JOIN `bigquery-public-data.crypto_bitcoin_cash.blocks` ON `bigquery-public-data.crypto_bitcoin_cash.transactions`.block_number = `bigquery-public-data.crypto_bitcoin_cash.blocks`.number
   WHERE is_coinbase is TRUE
   AND timestamp > '2018-01-01'
-  ORDER BY number
+  ORDER BY timestamp
 
 cardano:
   SELECT `iog-data-analytics.cardano_mainnet.block`.slot_no as number, `iog-data-analytics.cardano_mainnet.pool_offline_data`.ticker_name as identifiers, `iog-data-analytics.cardano_mainnet.block`.block_time as timestamp,`iog-data-analytics.cardano_mainnet.block`.pool_hash as reward_addresses
   FROM `iog-data-analytics.cardano_mainnet.block`
   LEFT JOIN `iog-data-analytics.cardano_mainnet.pool_offline_data` ON `iog-data-analytics.cardano_mainnet.block`.pool_hash = `iog-data-analytics.cardano_mainnet.pool_offline_data`.pool_hash
   WHERE `iog-data-analytics.cardano_mainnet.block`.block_time > '2018-01-01'
-  ORDER BY number
+  ORDER BY `iog-data-analytics.cardano_mainnet.block`.block_time
 
 dogecoin:
   SELECT block_number as number, block_timestamp as timestamp, coinbase_param as identifiers, `bigquery-public-data.crypto_dogecoin.transactions`.outputs
@@ -27,13 +27,13 @@ dogecoin:
   JOIN `bigquery-public-data.crypto_dogecoin.blocks` ON `bigquery-public-data.crypto_dogecoin.transactions`.block_number = `bigquery-public-data.crypto_dogecoin.blocks`.number
   WHERE is_coinbase is TRUE
   AND timestamp > '2018-01-01'
-  ORDER BY number
+  ORDER BY timestamp
 
 ethereum:
   SELECT number, timestamp, miner as reward_addresses, extra_data as identifiers
   FROM `bigquery-public-data.crypto_ethereum.blocks`
   WHERE timestamp > '2018-01-01'
-  ORDER BY number
+  ORDER BY timestamp
 
 
 litecoin:
@@ -42,13 +42,13 @@ litecoin:
   JOIN `bigquery-public-data.crypto_litecoin.blocks` ON `bigquery-public-data.crypto_litecoin.transactions`.block_number = `bigquery-public-data.crypto_litecoin.blocks`.number
   WHERE is_coinbase is TRUE
   AND timestamp > '2018-01-01'
-  ORDER BY number
+  ORDER BY timestamp
 
 tezos:
   SELECT level as number, timestamp, baker as reward_addresses
   FROM `public-data-finance.crypto_tezos.blocks`
   WHERE timestamp > '2018-01-01'
-  ORDER BY number
+  ORDER BY timestamp
 
 zcash:
   SELECT block_number as number, block_timestamp as timestamp, coinbase_param as identifiers, `bigquery-public-data.crypto_zcash.transactions`.outputs
@@ -56,5 +56,5 @@ zcash:
   JOIN `bigquery-public-data.crypto_zcash.blocks` ON `bigquery-public-data.crypto_zcash.transactions`.block_number = `bigquery-public-data.crypto_zcash.blocks`.number
   WHERE is_coinbase is TRUE
   AND timestamp > '2018-01-01'
-  ORDER BY number
+  ORDER BY timestamp
 


### PR DESCRIPTION
All Submissions:

* [x] Have you followed the guidelines in our [Contributing documentation](https://blockchain-technology-lab.github.io/pooling-analysis/contribute)?
* [x] Have you verified that there aren't any other open Pull Requests for the same update/change?
* [x] Does the Pull Request pass all tests?

# Description

Updated block data queries so that they all collect data from the same timestamp on (2018-01-01) and sort them based on block number
