### PR TITLE
Updated default parser to sort reward_addresses

### DIFF
--- a/consensus_decentralization/parsers/default_parser.py
+++ b/consensus_decentralization/parsers/default_parser.py
@@ -49,7 +49,7 @@ class DefaultParser:
 
         for block in data:
             block['reward_addresses'] = ','.join(sorted([tx['addresses'][0] for tx in block['outputs']
-                                                      if (tx['addresses'] and int(tx['value']) > MIN_TX_VALUE)]))
+                                                         if (tx['addresses'] and int(tx['value']) > MIN_TX_VALUE)]))
             del block['outputs']
             block['identifiers'] = self.parse_identifiers(block['identifiers'])
         return data

--- a/consensus_decentralization/parsers/default_parser.py
+++ b/consensus_decentralization/parsers/default_parser.py
@@ -48,7 +48,7 @@ class DefaultParser:
         data = self.read_and_sort_data()
 
         for block in data:
-            block['reward_addresses'] = ','.join(set([tx['addresses'][0] for tx in block['outputs']
+            block['reward_addresses'] = ','.join(sorted([tx['addresses'][0] for tx in block['outputs']
                                                       if (tx['addresses'] and int(tx['value']) > MIN_TX_VALUE)]))
             del block['outputs']
             block['identifiers'] = self.parse_identifiers(block['identifiers'])


### PR DESCRIPTION
All Submissions:

* [x] Have you followed the guidelines in our [Contributing documentation](https://blockchain-technology-lab.github.io/consensus-decentralization/contribute)?
* [x] Have you verified that there aren't any other open Pull Requests for the same update/change?
* [x] Does the Pull Request pass all tests?

# Description

The default parser sorts the `reward_addresses` field in `mapped_data.json` in the output directory.


